### PR TITLE
Fixed users with more spaces

### DIFF
--- a/views/default/mautic/mautic.php
+++ b/views/default/mautic/mautic.php
@@ -13,11 +13,10 @@ if(elgg_is_logged_in()) {
         $muser = elgg_get_logged_in_user_entity();
         $mguid = $muser->guid;
         $email = urlencode($muser->email);
-        $name = explode(" ", $muser->name);
+        $name = explode(" ", $muser->name, 2);
         $firstname = $name[0];
 	$firstname = rawurlencode($firstname);
         $lastname = $name[1];
-        $lastname .= " " . ($name[2]); //For users who use their  middlenames like "Walter Bruce Willis"
 	$lastname = rawurlencode($lastname);
 	$location = explode(",", $muser->location);
         $location = $location[0];


### PR DESCRIPTION
When an user had a name like "Wouter van Os Boom", it would go wrong. Now "van Os Boom" wil be handled as lastname.